### PR TITLE
Disable removeXMLNS while build

### DIFF
--- a/grunt/tasks/imagemin.js
+++ b/grunt/tasks/imagemin.js
@@ -12,7 +12,7 @@ const SVGO_OPTIONS = {
     { removeDesc: true },
     { removeViewBox: false },
     { removeUselessDefs: false },
-    { removeXMLNS: true },
+    { removeXMLNS: false },
     { removeRasterImages: true },
     { cleanupIDs: false },
     {


### PR DESCRIPTION
После билда файлы svg лишались атрибута xml. Из-за этого они не выводились на сайте.